### PR TITLE
Fixed the compilation errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/src/version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4.3", "Cython"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/version.py"
+write_to_template = "__version__ = \"{version}\""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,41 @@
+[metadata]
+name = pymspack
+version = 0.2.0
+author = Gaetan Crahay
+author_email = gaetan@crahay.eu
+license = BSD license
+description = Python bindings to libmspack
+keywords = pymspack
+url = https://github.com/gcrahay/pymspack
+long_description = file: README.rst, HISTORY.rst
+long_description_content_type = text/x-rst
+
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+package_dir =
+  pymspack = src
+packages = pymspack
+zip_safe = False
+setup_requires = setuptools>=42; wheel; setuptools_scm[toml]>=3.4.3; Cython
+include_package_data = True
+tests_require = pytest
+
 [bumpversion]
 current_version = 0.1.0
 commit = True
 tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:pymspack/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
 
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -6,54 +6,11 @@ from setuptools.extension import Extension
 
 try:
     from Cython.Build import cythonize
-    ext_modules = cythonize([Extension("pymspack.ext", ["src/ext.pyx"], libraries=["mspack"])])
+    ext_modules = [Extension("pymspack.ext", ["src/ext.c"], libraries=["mspack"])]
 except ImportError:
     print("Yous should have Cython installed to build this package extension.")
     import sys
     sys.exit()
 
-
-with open('README.rst') as readme_file:
-    readme = readme_file.read()
-
-with open('HISTORY.rst') as history_file:
-    history = history_file.read()
-
-requirements = [
-    # TODO: put package requirements here
-]
-
-test_requirements = [
-    'pytest'
-]
-
-setup(
-    name='pymspack',
-    version='0.2.0',
-    description="Python bindings to libmspack",
-    long_description=readme + '\n\n' + history,
-    author="Gaetan Crahay",
-    author_email='gaetan@crahay.eu',
-    url='https://github.com/gcrahay/pymspack',
-    include_package_data=True,
-    install_requires=requirements,
-    license="BSD license",
-    zip_safe=False,
-    keywords='pymspack',
-    setup_requires=['Cython', ],
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-    ],
-    test_suite='tests',
-    tests_require=test_requirements,
-    ext_modules=ext_modules,
-    packages=['pymspack',],
-    package_dir={"pymspack": "src"},
-)
+if __name__ == "__main__":
+    setup(ext_modules=ext_modules)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
+from .version import __version__
 from .ext import *

--- a/src/ext.pxd
+++ b/src/ext.pxd
@@ -1,3 +1,4 @@
+#cython: language_level=3
 cdef extern from "mspack.h":
     cdef struct mscab_decompressor:
         mscabd_cabinet * (*open) (mscab_decompressor *self, const char *filename)
@@ -25,27 +26,27 @@ cdef extern from "mspack.h":
     cdef struct mspack_system:
         pass
 
-    cdef int MSCAB_ATTRIB_RDONLY
-    cdef int MSCAB_ATTRIB_HIDDEN
-    cdef int MSCAB_ATTRIB_SYSTEM
-    cdef int MSCAB_ATTRIB_ARCH
-    cdef int MSCAB_ATTRIB_EXEC
-    cdef int MSCAB_ATTRIB_UTF_NAME
+    cdef const int MSCAB_ATTRIB_RDONLY
+    cdef const int MSCAB_ATTRIB_HIDDEN
+    cdef const int MSCAB_ATTRIB_SYSTEM
+    cdef const int MSCAB_ATTRIB_ARCH
+    cdef const int MSCAB_ATTRIB_EXEC
+    cdef const int MSCAB_ATTRIB_UTF_NAME
 
-    cdef int MSPACK_ERR_OK
-    cdef int MSPACK_ERR_ARGS
-    cdef int MSPACK_ERR_OPEN
-    cdef int MSPACK_ERR_READ
-    cdef int MSPACK_ERR_WRITE
-    cdef int MSPACK_ERR_SEEK
-    cdef int MSPACK_ERR_NOMEMORY
-    cdef int MSPACK_ERR_SIGNATURE
-    cdef int MSPACK_ERR_DATAFORMAT
-    cdef int MSPACK_ERR_CHECKSUM
-    cdef int MSPACK_ERR_CRUNCH
-    cdef int MSPACK_ERR_DECRUNCH
+    cdef const int MSPACK_ERR_OK
+    cdef const int MSPACK_ERR_ARGS
+    cdef const int MSPACK_ERR_OPEN
+    cdef const int MSPACK_ERR_READ
+    cdef const int MSPACK_ERR_WRITE
+    cdef const int MSPACK_ERR_SEEK
+    cdef const int MSPACK_ERR_NOMEMORY
+    cdef const int MSPACK_ERR_SIGNATURE
+    cdef const int MSPACK_ERR_DATAFORMAT
+    cdef const int MSPACK_ERR_CHECKSUM
+    cdef const int MSPACK_ERR_CRUNCH
+    cdef const int MSPACK_ERR_DECRUNCH
 
-    int MSPACK_SYS_SELFTEST(int)
+    void MSPACK_SYS_SELFTEST(int)
 
     mscab_decompressor *mspack_create_cab_decompressor(mspack_system *sys)
     void mspack_destroy_cab_decompressor(mscab_decompressor *self)


### PR DESCRIPTION
 Cython now has to be called explicitly (cythonize is badly broken).
Improved error reporting.
Moved the metadata into `setup.cfg` and now the version is set with setuptools_scm.

Though the issue is that it doesn't work. On Ubuntu Eoan it raises an error. IDK if it is because of the lib or if it is because of us doing something wrong.

In any case, I have fixed the building, so I think it should be merged.